### PR TITLE
fix: added missing execserver resources config setting

### DIFF
--- a/charts/execserver/templates/configmap.yaml
+++ b/charts/execserver/templates/configmap.yaml
@@ -24,6 +24,7 @@ data:
         noColor: false
         # add hostname to log output
         addHostname: true
+      resources: "/fylr/files/resources"
       services:
         execserver:
           addr: :7070


### PR DESCRIPTION
# Description

This PR fixes a problem related to execserver startup. In previous versions of fylr it was not necessary to define the resources, but this behavior was changed a few days ago.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

See automated tests.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

