### PR TITLE
feature: implemented execserver prometheus pod and service monitor

### DIFF
--- a/charts/execserver/templates/prometheus_monitoring.yaml
+++ b/charts/execserver/templates/prometheus_monitoring.yaml
@@ -1,0 +1,33 @@
+# service monitoring
+{{ if .Values.monitoring.service.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "execserver.fullname" . }}
+  labels:
+    {{- include "execserver.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "execserver.labels" . | nindent 6 }}
+  endpoints:
+  - port: http
+    {{ if .Values.monitoring.service.interval }}interval: {{ .Values.monitoring.service.interval }}{{ end }}
+{{ end }}
+
+# pod monitoring
+{{ if .Values.monitoring.pod.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "execserver.fullname" . }}
+  labels:
+    {{- include "execserver.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "execserver.labels" . | nindent 6 }}
+  podMetricsEndpoints:
+  - port: http
+    {{ if .Values.monitoring.pod.interval }}interval: {{ .Values.monitoring.pod.interval }}{{ end }}
+{{ end }}

--- a/charts/execserver/values.yaml
+++ b/charts/execserver/values.yaml
@@ -40,6 +40,14 @@ service:
   type: ClusterIP
   port: 8070
 
+monitoring:
+  service:
+    enabled: false
+    interval: "30s"
+  pod:
+    enabled: false
+    interval: "30s"
+
 ingress:
   enabled: false
   className: ""


### PR DESCRIPTION
# Description

This PR adds the service and pod monitor to the execserver helm chart. In order to use that functionality, we require the prometheus-operator to be installed. If that's not the case, helm is going to throw an error (expected).

## Type of change

Please delete options that are not relevant.

- [x] Enhancement (non-breaking change which improves existing functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

See CI

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

