### PR TITLE
fix: fylr binary references

### DIFF
--- a/charts/execserver/templates/configmap.yaml
+++ b/charts/execserver/templates/configmap.yaml
@@ -142,8 +142,8 @@ data:
             pdf2pages:
               waitgroup: {{ .Values.fylr.execserver.services.pdf2pages.waitGroup | quote }}
               commands:
-                pdf2pages:
-                  prog: "pdf2pages"
+                fylr_pdf2pages:
+                  prog: "fylr_pdf2pages"
                 fylr_metadata:
                   prog: "fylr_metadata"
             {{ end }}
@@ -158,8 +158,8 @@ data:
             copy:
               waitgroup: {{ .Values.fylr.execserver.services.copy.waitGroup | quote }}
               commands:
-                copy:
-                  prog: "copy"
+                fylr_copy:
+                  prog: "fylr_copy"
             {{ end }}
             {{ if .Values.fylr.execserver.services.metadata.enabled }}
             metadata:
@@ -180,8 +180,8 @@ data:
             iiif:
               waitgroup: {{ .Values.fylr.execserver.services.iiif.waitGroup | quote }}
               commands:
-                iiif_im:
-                  prog: "iiif_im"
+                fylr_iiif:
+                  prog: "fylr_iiif"
                   startupCheck:
                     args:
                       - "-version"


### PR DESCRIPTION
# Description

This PR matches the new fylr binary format naming scheme. This is necessary in order to run the execserver.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- Kubernetes version:
- Kubectl version:
- Helm version:
- Node operation system:

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
