### PR TITLE
Update README.md

### DIFF
--- a/charts/fylr/README.md
+++ b/charts/fylr/README.md
@@ -25,9 +25,9 @@ ingress:
     cert-manager.io/cluster-issuer: letsencrypt
   hosts:
   - host: ${DOMAIN}
-      paths:
-        - path: /
-          pathType: ImplementationSpecific
+    paths:
+    - path: /
+      pathType: ImplementationSpecific
   tls:
   - secretName: chart-example-tls
     hosts:


### PR DESCRIPTION
fixed indentation which caused: line 8: mapping values are not allowed in this context

# Description

indentation was wrong in the "paths:" line. 

changed a few lines more in the same go

## How Has This Been Tested?

tested fix with: helm install
