### PR TITLE
fix: fylr generated disk block volume ident

### DIFF
--- a/charts/fylr/Chart.yaml
+++ b/charts/fylr/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/fylr/templates/_helpers.tpl
+++ b/charts/fylr/templates/_helpers.tpl
@@ -166,21 +166,21 @@ system:
   mountPath: "/fylr/files/assets/originals"
   subPath: "originals"
 {{/* end if is originals */}}
-{{- end -}}
+{{- end }}
 {{/* check if key is defined as versions */}}
 {{- if eq $key $persistent.defaults.versions -}}
 {{- if eq $key $persistent.defaults.originals -}}
 - name: "disk-one"
   mountPath: "/fylr/files/assets/versions"
   subPath: "versions"
-{{- else -}}
+{{- else }}
 - name: "disk-two"
   mountPath: "/fylr/files/assets/versions"
   subPath: "versions"
 {{/* end if key is originals as well */}}
-{{- end -}}
+{{- end }}
 {{/* end if is versions */}}
-{{- end -}}
+{{- end }}
 {{/* check if key is defined as backups */}}
 {{- if eq $key $persistent.defaults.backups -}}
 {{/* check if key is same as originals*/}}
@@ -194,23 +194,23 @@ system:
 - name: "disk-two"
   mountPath: "/fylr/files/backups"
   subPath: "backups"
-{{- else -}}
+{{- else }}
 {{/* key is not the same as defaults.originals and defaults.versions */}}
 - name: "disk-three"
   mountPath: "/fylr/files/backups"
   subPath: "backups"
 {{/* end if key eq defaults.versions and ne defaults.originals */}}
-{{- end -}}
+{{- end }}
 {{/* end if key is originals */}}
-{{- end -}}
+{{- end }}
 {{/* end if key is backups */}}
-{{- end -}}
+{{- end }}
 {{/* end if key is any of originals, versions, backups */}}
-{{- end -}}
+{{- end }}
 {{/* end if is kind disk */}}
-{{- end -}}
+{{- end }}
 {{/* end loop */}}
-{{- end -}}
+{{- end }}
 {{/* end define */}}
 {{- end -}}
 


### PR DESCRIPTION
# Description

Before this change was introduced and the user defined a single drive for `versions`, `originals` and `backups`, the created volumeMounts block was incorrectly shaped.

## How Has This Been Tested?

- make install-fylr-dev

**Test Configuration**:

- Kubernetes version: `v1.25.0`
- Kubectl version: `v1.25.0`
- Helm version: `v3.9.2`
- Node operation system: `ubuntu 22.04`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
