### PR TITLE
Enhancement: use the same name as in apitestst for oauth default client ID

### DIFF
--- a/charts/fylr/templates/configmap.yaml
+++ b/charts/fylr/templates/configmap.yaml
@@ -63,7 +63,7 @@ data:
           addr: :8080
           path: /fylr/files/webfrontend
           oauth2:
-            clientID: "webclient"
+            clientID: "web-client"
           reverseProxy:
             api: "http://{{ include "fylr.service-api-name" . }}.{{ .Release.Namespace }}.svc:{{ .Values.services.api.port }}"
             backend: "http://{{ include "fylr.service-backend-name" . }}.{{ .Release.Namespace }}.svc:{{ .Values.services.backend.port }}"
@@ -75,7 +75,7 @@ data:
           addr: :8081
           oauth2Server:
             clients:
-              webclient:
+              web-client:
                 redirectURIs:
                   - {{ .Values.fylr.externalURL }}/oauth2/callback
                 scopes:


### PR DESCRIPTION
# Description
use the same name as in apitestst for oauth default client ID
