### PR TITLE
Fix: name clientid consistently

### DIFF
--- a/charts/fylr/Chart.yaml
+++ b/charts/fylr/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.4
+version: 0.1.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/fylr/README.md
+++ b/charts/fylr/README.md
@@ -89,7 +89,7 @@ helm install ${RELEASE_NAME} fylr/fylr \
 
 These two secrets are used by the fylr installation to sign, encrypt, and configure the OAuth2 client and server. The values are generated during installation and are not updated during upgrades or deleted during uninstallation. If you want to change the values, you must adjust them manually.
 
-So if you want to know the secret to connect as "webclient", the default OAuth2 clientID:
+So if you want to know the secret to connect as "web-client", the default OAuth2 clientID:
 
 ```bash
 kubectl -n ${NAMESPACE} get secrets REPLACE_ME-fylr-oauth2 -o go-template={{.data.oauth2WebappClientSecret}} | base64 -d;echo

--- a/charts/fylr/templates/deployment.yaml
+++ b/charts/fylr/templates/deployment.yaml
@@ -145,7 +145,7 @@ spec:
                 secretKeyRef:
                   name: {{ include "fylr.secret.elastic.name" . }}
                   key: "hosts"
-            - name: CFG_FYLR_SERVICES_API_OAUTH2SERVER_CLIENTS_webclient_SECRET
+            - name: CFG_FYLR_SERVICES_API_OAUTH2SERVER_CLIENTS_web-client_SECRET
               valueFrom:
                 secretKeyRef:
                   name: {{ include "fylr.secret.oauth2.name" . }}


### PR DESCRIPTION
# Description
make sure clientID for web app is written in the same ways everywhere: web-client