### PR TITLE
use the updated execserver chart in the dependencies

### DIFF
--- a/charts/fylr/Chart.yaml
+++ b/charts/fylr/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.8
+version: 0.1.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -38,6 +38,6 @@ dependencies:
     condition: elasticsearch.enabled
   # https://programmfabrik.github.io/fylr-helm/charts/execserver/
   - name: execserver
-    version: 0.1.1
+    version: 0.1.4
     repository: https://programmfabrik.github.io/fylr-helm
     condition: execserver.enabled


### PR DESCRIPTION
# Description

use the updated execserver chart with fylr v6.2.0 in the dependencies of the main fylr helm chart