### PR TITLE
execserver helm chart with fylr 6.2.4

### DIFF
--- a/charts/execserver/Chart.yaml
+++ b/charts/execserver/Chart.yaml
@@ -7,13 +7,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.6
+version: 0.1.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v6.2.3"
+appVersion: "v6.2.4"
 
 maintainers:
   - name: programmfabrik

--- a/charts/execserver/values.yaml
+++ b/charts/execserver/values.yaml
@@ -12,7 +12,7 @@ image:
   pullPolicy: IfNotPresent
   # -- The image tag
   # Overrides the image tag whose default value is the appVersion of the chart.
-  tag: "v6.2.3"
+  tag: "v6.2.4"
 
 # -- Pull secrets for the image. Useful for private registries. See https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 imagePullSecrets: []

--- a/charts/fylr/Chart.yaml
+++ b/charts/fylr/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.11
+version: 0.1.12
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
# Description

execserver helm chart with fylr 6.2.4

fylr chart version update to contain the changes in it's README.md. Otherwise cr (chart releaser) would be blocked from making the execserver release.

For #67138