### PR TITLE
Startup time flexibilty

### DIFF
--- a/charts/fylr/Chart.yaml
+++ b/charts/fylr/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.49
+version: 0.1.50
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/fylr/templates/deployment.yaml
+++ b/charts/fylr/templates/deployment.yaml
@@ -168,26 +168,42 @@ spec:
           envFrom:
             - secretRef:
                 name: {{ include "fylr.secret.storage.name" . }}
+          {{- if .Values.fylr.startupProbe.enabled }}
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: backend
+              scheme: HTTP
+            initialDelaySeconds: {{ .Values.fylr.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.fylr.startupProbe.periodSeconds }}
+            successThreshold: {{ .Values.fylr.startupProbe.successThreshold }}
+            failureThreshold: {{ .Values.fylr.startupProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.fylr.startupProbe.timeoutSeconds }}
+          {{- end }}
+          {{- if .Values.fylr.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
               path: /healthz
               port: backend
               scheme: HTTP
-            initialDelaySeconds: 20
-            periodSeconds: 30
-            successThreshold: 1
-            failureThreshold: 3
-            timeoutSeconds: 5
+            initialDelaySeconds: {{ .Values.fylr.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.fylr.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.fylr.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.fylr.readinessProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.fylr.readinessProbe.timeoutSeconds }}
+          {{- end }}
+          {{- if .Values.fylr.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
               path: /healthz
               port: backend
               scheme: HTTP
-            initialDelaySeconds: 30
-            periodSeconds: 30
-            successThreshold: 1
-            failureThreshold: 3
-            timeoutSeconds: 5
+            initialDelaySeconds: {{ .Values.fylr.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.fylr.livenessProbe.periodSeconds }}
+            successThreshold: {{ .Values.fylr.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.fylr.livenessProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.fylr.livenessProbe.timeoutSeconds }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/charts/fylr/values.yaml
+++ b/charts/fylr/values.yaml
@@ -127,6 +127,55 @@ fylr:
   externalURL: "http://localhost"
   # -- (bool) set to true to allow /api/settings/purge. should be disabled for production!
   allowPurge: true
+
+  ## Configure liveness, readiness and startup probes
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
+  ##
+  ## startup probe: Liveness and readiness probes do not start until this succeeds.
+  ## @param fylr.startupProbe.enabled Enable/disable the startup probe
+  ## @param fylr.startupProbe.initialDelaySeconds Delay before startup probe is initiated
+  ## @param fylr.startupProbe.periodSeconds How often to perform the probe
+  ## @param fylr.startupProbe.timeoutSeconds When the probe times out
+  ## @param fylr.startupProbe.successThreshold Minimum consecutive successes for the probe to be considered successful after having failed
+  ## @param fylr.startupProbe.failureThreshold Minimum consecutive failures for the probe to be considered failed after having succeeded
+  startupProbe:
+    enabled: true
+    initialDelaySeconds: 1
+    periodSeconds: 5
+    timeoutSeconds: 10
+    successThreshold: 1
+    failureThreshold: 100
+  ##
+  ## liveness probe: Not live -> restart container
+  ## @param fylr.livenessProbe.enabled Enable/disable the liveness probe
+  ## @param fylr.livenessProbe.initialDelaySeconds Delay before liveness probe is initiated
+  ## @param fylr.livenessProbe.periodSeconds How often to perform the probe
+  ## @param fylr.livenessProbe.timeoutSeconds When the probe times out
+  ## @param fylr.livenessProbe.successThreshold Minimum consecutive successes for the probe to be considered successful after having failed
+  ## @param fylr.livenessProbe.failureThreshold Minimum consecutive failures for the probe to be considered failed after having succeeded
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 1
+    periodSeconds: 30
+    timeoutSeconds: 5
+    successThreshold: 1
+    failureThreshold: 3
+  ##
+  ## readiness probe: Not ready -> Does not accept traffic, removed from Service load balancer
+  ## @param fylr.readinessProbe.enabled Enable/disable the readiness probe
+  ## @param fylr.readinessProbe.initialDelaySeconds Delay before readiness probe is initiated
+  ## @param fylr.readinessProbe.periodSeconds How often to perform the probe
+  ## @param fylr.readinessProbe.timeoutSeconds When the probe times out
+  ## @param fylr.readinessProbe.successThreshold Minimum consecutive successes for the probe to be considered successful after having failed
+  ## @param fylr.readinessProbe.failureThreshold Minimum consecutive failures for the probe to be considered failed after having succeeded
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 1
+    periodSeconds: 30
+    timeoutSeconds: 5
+    successThreshold: 1
+    failureThreshold: 3
+  
   # -- (object) settings related to the logging
   logger:
     # -- (string) format is the format of the logs. Valid values are "json" and "console".

--- a/charts/fylr/values.yaml
+++ b/charts/fylr/values.yaml
@@ -598,12 +598,12 @@ elasticsearch:
     ## @param master.startupProbe.failureThreshold Minimum consecutive failures for the probe to be considered failed after having succeeded
     ##
     startupProbe:
-      enabled: false
+      enabled: true
       initialDelaySeconds: 90
       periodSeconds: 10
       timeoutSeconds: 5
       successThreshold: 1
-      failureThreshold: 5
+      failureThreshold: 20
     ## @param master.livenessProbe.enabled Enable/disable the liveness probe (master-eligible nodes pod)
     ## @param master.livenessProbe.initialDelaySeconds Delay before liveness probe is initiated (master-eligible nodes pod)
     ## @param master.livenessProbe.periodSeconds How often to perform the probe (master-eligible nodes pod)
@@ -613,7 +613,7 @@ elasticsearch:
     ##
     livenessProbe:
       enabled: true
-      initialDelaySeconds: 90
+      initialDelaySeconds: 1
       periodSeconds: 10
       timeoutSeconds: 5
       successThreshold: 1
@@ -627,7 +627,7 @@ elasticsearch:
     ##
     readinessProbe:
       enabled: true
-      initialDelaySeconds: 90
+      initialDelaySeconds: 1
       periodSeconds: 10
       timeoutSeconds: 5
       successThreshold: 1
@@ -762,12 +762,12 @@ elasticsearch:
     ## @param data.startupProbe.failureThreshold Minimum consecutive failures for the probe to be considered failed after having succeeded
     ##
     startupProbe:
-      enabled: false
-      initialDelaySeconds: 90
+      enabled: true
+      initialDelaySeconds: 1
       periodSeconds: 10
       timeoutSeconds: 5
       successThreshold: 1
-      failureThreshold: 5
+      failureThreshold: 20
     ## @param data.livenessProbe.enabled Enable/disable the liveness probe (data nodes pod)
     ## @param data.livenessProbe.initialDelaySeconds Delay before liveness probe is initiated (data nodes pod)
     ## @param data.livenessProbe.periodSeconds How often to perform the probe (data nodes pod)
@@ -777,7 +777,7 @@ elasticsearch:
     ##
     livenessProbe:
       enabled: true
-      initialDelaySeconds: 90
+      initialDelaySeconds: 1
       periodSeconds: 10
       timeoutSeconds: 5
       successThreshold: 1
@@ -791,7 +791,7 @@ elasticsearch:
     ##
     readinessProbe:
       enabled: true
-      initialDelaySeconds: 90
+      initialDelaySeconds: 1
       periodSeconds: 10
       timeoutSeconds: 5
       successThreshold: 1
@@ -1057,12 +1057,12 @@ elasticsearch:
     ## @param coordinating.startupProbe.failureThreshold Minimum consecutive failures for the probe to be considered failed after having succeeded
     ##
     startupProbe:
-      enabled: false
-      initialDelaySeconds: 90
+      enabled: true
+      initialDelaySeconds: 1
       periodSeconds: 10
       timeoutSeconds: 5
       successThreshold: 1
-      failureThreshold: 5
+      failureThreshold: 20
     ## @param coordinating.livenessProbe.enabled Enable/disable the liveness probe (coordinating-only nodes pod)
     ## @param coordinating.livenessProbe.initialDelaySeconds Delay before liveness probe is initiated (coordinating-only nodes pod)
     ## @param coordinating.livenessProbe.periodSeconds How often to perform the probe (coordinating-only nodes pod)
@@ -1072,7 +1072,7 @@ elasticsearch:
     ##
     livenessProbe:
       enabled: true
-      initialDelaySeconds: 90
+      initialDelaySeconds: 1
       periodSeconds: 10
       timeoutSeconds: 5
       successThreshold: 1
@@ -1086,7 +1086,7 @@ elasticsearch:
     ##
     readinessProbe:
       enabled: true
-      initialDelaySeconds: 90
+      initialDelaySeconds: 1
       periodSeconds: 10
       timeoutSeconds: 5
       successThreshold: 1
@@ -1322,12 +1322,12 @@ elasticsearch:
     ## @param ingest.startupProbe.failureThreshold Minimum consecutive failures for the probe to be considered failed after having succeeded
     ##
     startupProbe:
-      enabled: false
-      initialDelaySeconds: 90
+      enabled: true
+      initialDelaySeconds: 1
       periodSeconds: 10
       timeoutSeconds: 5
       successThreshold: 1
-      failureThreshold: 5
+      failureThreshold: 20
     ## @param ingest.livenessProbe.enabled Enable/disable the liveness probe (ingest-only nodes pod)
     ## @param ingest.livenessProbe.initialDelaySeconds Delay before liveness probe is initiated (ingest-only nodes pod)
     ## @param ingest.livenessProbe.periodSeconds How often to perform the probe (ingest-only nodes pod)
@@ -1337,7 +1337,7 @@ elasticsearch:
     ##
     livenessProbe:
       enabled: true
-      initialDelaySeconds: 90
+      initialDelaySeconds: 1
       periodSeconds: 10
       timeoutSeconds: 5
       successThreshold: 1
@@ -1351,7 +1351,7 @@ elasticsearch:
     ##
     readinessProbe:
       enabled: true
-      initialDelaySeconds: 90
+      initialDelaySeconds: 1
       periodSeconds: 10
       timeoutSeconds: 5
       successThreshold: 1
@@ -1754,7 +1754,7 @@ elasticsearch:
     ##
     livenessProbe:
       enabled: true
-      initialDelaySeconds: 60
+      initialDelaySeconds: 1
       periodSeconds: 10
       timeoutSeconds: 5
       successThreshold: 1
@@ -1770,7 +1770,7 @@ elasticsearch:
     ##
     readinessProbe:
       enabled: true
-      initialDelaySeconds: 5
+      initialDelaySeconds: 1
       periodSeconds: 10
       timeoutSeconds: 1
       successThreshold: 1
@@ -1785,12 +1785,12 @@ elasticsearch:
     ## @param metrics.startupProbe.successThreshold Minimum consecutive successes for the probe to be considered successful after having failed (metrics pod)
     ##
     startupProbe:
-      enabled: false
-      initialDelaySeconds: 5
+      enabled: true
+      initialDelaySeconds: 1
       periodSeconds: 10
-      timeoutSeconds: 1
+      timeoutSeconds: 2
       successThreshold: 1
-      failureThreshold: 5
+      failureThreshold: 40
     ## @param metrics.customStartupProbe Custom liveness probe for the Web component
     ##
     customStartupProbe: {}

--- a/charts/fylr/values.yaml
+++ b/charts/fylr/values.yaml
@@ -193,7 +193,7 @@ fylr:
     addHostname: true
 
   debug:
-    # this setting skips the sometime expensive permission check
+    # this setting skips the sometimes expensive permission check
     # on the /api/eas/download endpoint. However, there is still
     # some security left, the link is checked against a valid hash
     # of the file which needs to be provided.


### PR DESCRIPTION
# Description

This pull request changes:
* now via values.yaml the readinessProbe and livenessProbe for fylr can be disabled
* new: startupProbe for fylr
* probe timings have been changed, for fylr and elasticsearch: more startupProbe time, less initial delay time in all probes.

A partner reported:

Beim HelmChart Deployment (Upgrade 6.7.4 -> 6.8.1) ist ein Kundensystem in einer Restart-Schleife hängengeblieben.
Es stellte sich heraus, dass das DB Update sehr lange dauerte - knapp 10min(!)
Der definierte Start-Check war viel zu kurz eingestellt, dass der Readness Probe zu kurz ist und so der Server immer wieder neu startet. Ich habe das Chart ausgepackt in die Einstellungen gelöscht - dann ging es.


## How Has This Been Tested?

Deployment in a cluster with a few different settings for the probes.