### PR TITLE
update default OAuth2 clients

### DIFF
--- a/charts/fylr/Chart.yaml
+++ b/charts/fylr/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.93
+version: 0.1.94
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/fylr/README.md
+++ b/charts/fylr/README.md
@@ -118,23 +118,30 @@ Depending on your configuration, you can deploy fylr with a persistent volume. I
 
 ### Secrets
 
-- `<deployment-name>-fylr-oauth2`
-- `<deployment-name>-fylr-utils`
+- `fylr*utils`
 
-These two secrets are used by the fylr installation to sign, encrypt, and configure the OAuth2 client and server. The values are generated during installation and are not updated during upgrades or deleted during uninstallation. If you want to change the values, you must adjust them manually.
+This secret is used by the fylr installation for the OAuth2 server. The value is generated during installation and not updated during upgrades or deleted during uninstallation. If you want to change the values, you must adjust them manually.
 
-So if you want to know the secret to connect as "web-client", the default OAuth2 clientID:
+How to read out a secret:
 
-Get the secret name:
+Get secret names:
 
 ```bash
 kubectl -n ${NAMESPACE} get secrets
 ```
 
-Choose the secret name ending in `-fylr-oauth2`. For this example, we assume the name is `example-fylr-oauth2`.
+Choose the secret name with `fylr*utils`. For this example, we assume the name is `fylr-helm-test-utils`.
+
+view the structure:
 
 ```bash
-kubectl -n ${NAMESPACE} get secrets example-fylr-oauth2 -o go-template={{.data.oauth2WebappClientSecret}} | base64 -d;echo
+kubectl -n ${NAMESPACE} get secrets fylr-helm-test-utils -o json
+```
+
+output one string of the secret:
+
+```bash
+kubectl -n ${NAMESPACE} get secrets fylr-helm-test-utils -o go-template={{.data.encryptionKey}} | base64 -d;echo
 ```
 
 ## Configuration

--- a/charts/fylr/templates/_helpers.tpl
+++ b/charts/fylr/templates/_helpers.tpl
@@ -111,10 +111,6 @@ Secret names
 {{- printf "%s-%s" (include "fylr.fullname" .) "init" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
-{{- define "fylr.secret.oauth2.name" -}}
-{{- printf "%s-%s" (include "fylr.fullname" .) "oauth2" | trunc 63 | trimSuffix "-" }}
-{{- end }}
-
 {{- define "fylr.secret.utils" -}}
 {{- printf "%s-%s" (include "fylr.fullname" .) "utils" | trunc 63 | trimSuffix "-" }}
 {{- end }}

--- a/charts/fylr/templates/configmap.yaml
+++ b/charts/fylr/templates/configmap.yaml
@@ -84,7 +84,7 @@ data:
         webapp:
           addr: :8080
           oauth2:
-            clientID: "web-client"
+            clientID: "fylr-web-frontend"
             internalURL:  "http://{{ include "fylr.service-api-name" . }}.{{ .Release.Namespace }}.svc:{{ .Values.services.api.port }}"
           reverseProxy:
             api: "http://{{ include "fylr.service-api-name" . }}.{{ .Release.Namespace }}.svc:{{ .Values.services.api.port }}"
@@ -98,7 +98,7 @@ data:
           addr: :8081
           oauth2Server:
             clients:
-              web-client:
+              fylr-web-frontend:
                 redirectURIs:
                   - {{ .Values.fylr.externalURL }}/oauth2/callback
                 scopes:
@@ -108,7 +108,7 @@ data:
                 public: true
               # add custom clients
               {{- if .Values.fylr.services.api.oauth2Server.clients }}
-              {{- toYaml .Values.fylr.services.api.oauth2Server.clients | nindent 12 }}
+              {{- toYaml .Values.fylr.services.api.oauth2Server.clients | nindent 14 }}
               {{- end }}
         backend:
           addr: :8082

--- a/charts/fylr/templates/deployment.yaml
+++ b/charts/fylr/templates/deployment.yaml
@@ -147,16 +147,6 @@ spec:
                 secretKeyRef:
                   name: {{ include "fylr.secret.elastic.name" . }}
                   key: "hosts"
-            - name: CFG_FYLR_SERVICES_API_OAUTH2SERVER_CLIENTS_web-client_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "fylr.secret.oauth2.name" . }}
-                  key: "oauth2ServerClientSecret"
-            - name: CFG_FYLR_SERVICES_WEBAPP_OAUTH2_CLIENTSECRET
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "fylr.secret.oauth2.name" . }}
-                  key: "oauth2WebappClientSecret"
             - name: CFG_FYLR_ENCRYPTIONKEY
               valueFrom:
                 secretKeyRef:

--- a/charts/fylr/templates/secrets.yaml
+++ b/charts/fylr/templates/secrets.yaml
@@ -43,25 +43,6 @@ stringData:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "fylr.secret.oauth2.name" . }}
-  labels:
-    {{- include "fylr.labels" . | nindent 4 }}
-  annotations:
-    helm.sh/hook: pre-install
-    helm.sh/hook-weight: "1"
-    helm.sh/resource-policy: keep
-type: Opaque
-stringData:
-  {{ $placeholderuser := "placeholder" }}
-  {{ $plaintextpassword := (randAlphaNum 32) }}
-  {{/* generate the bcrypt hash and remove the username: prefix from the string */}}
-  {{ $oauth2_webapp_client_secret := trimPrefix (printf "%s:" $placeholderuser) (htpasswd $placeholderuser $plaintextpassword) }}
-  oauth2ServerClientSecret: {{ $oauth2_webapp_client_secret | quote }}
-  oauth2WebappClientSecret: {{ $plaintextpassword | quote }}
----
-apiVersion: v1
-kind: Secret
-metadata:
   name: {{ include "fylr.secret.utils" . }}
   labels:
     {{- include "fylr.labels" . | nindent 4 }}

--- a/charts/fylr/values.yaml
+++ b/charts/fylr/values.yaml
@@ -456,7 +456,35 @@ fylr:
       oauth2Server:
         # -- (object) additional oauth2 clients to be added to the oauth2 server.
         # For the web application, we automatically generate a key pair and assign it to the oauth2 client.
-        clients: {}
+        clients:
+          fylr-mobile-app:
+            public: true
+            redirectURIs:
+              - "fylr.app.scheme:///"
+            scopes:
+              - "read"
+              - "write"
+              - "offline"
+          ci-hub:
+            public: true
+            redirectURIs:
+              - "https://ci-hub.azurewebsites.net/api/v1/auth/login/fylr"
+              - "https://ci-hub-beta.azurewebsites.net/api/v1/auth/login/fylr"
+              - "https://ci-hub-test.azurewebsites.net/api/v1/auth/login/fylr"
+              - "http://localhost:8080/api/v1/auth/login/fylr"
+            scopes:
+              - "read"
+              - "write"
+              - "offline"
+          santa-cruz:
+            public: true
+            redirectURIs:
+              - "https://fylr.linkrui.com/oauth"
+              - "https://stage-fylr.linkrui.com/oauth"
+            scopes:
+              - "read"
+              - "write"
+              - "offline"
           # my-client-id:
           #   # secret must be given as bcrypt hash
           #   secret: $2y$04$81xGNnm8PS1uiIzjbos6Le3NzFaNB0goNqnBpOx7S/EyrayzJCNAq # foo


### PR DESCRIPTION
# Description
- default OAuth2 client changed from "web-client" to "fylr-web-frontend"
- adding optional OAuth2 clients to values.yaml
- bugfix: indentation of optional oauth2 clients corrected in configmap representing fylr.yml
- as clients are public, some secrets have been removed

# How Has This Been Tested?
- deployed in a kubernetes cluster
- browser test confirms oauth2 still works between default client and server 
- output in /insepct/config confirms that default client and optional clients are changed
- asset upload confirms that there are no obvious side effects harming basic fylr functionality
