### PR TITLE
internal execserver

### DIFF
--- a/charts/fylr/Chart.yaml
+++ b/charts/fylr/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.95
+version: 0.1.96
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/fylr/README.md
+++ b/charts/fylr/README.md
@@ -144,6 +144,25 @@ output one string of the secret:
 kubectl -n ${NAMESPACE} get secrets fylr-helm-test-utils -o go-template={{.data.encryptionKey}} | base64 -d;echo
 ```
 
+## Internal Execserver
+
+This is a variation of deployment:
+* no execserver pod is created
+* execserver functionality is instead used in the one remaining fylr pod
+* the one fylr pod is thus bigger, as the container image with 3rd party tools has to be pulled
+* as the execserver pod is omitted, this uses less resources overall (when replica is 1)
+* for small instances
+
+To use this variant, include this in your `values.yaml`:
+
+´´´yaml
+image:
+  repository: docker.fylr.io/fylr/fylr
+execserver:
+  enabled: false
+[...]
+´´´
+
 ## Configuration
 
 The link below contains a table of the configurable parameters and their default values.

--- a/charts/fylr/templates/configmap.yaml
+++ b/charts/fylr/templates/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "fylr.labels" . | nindent 4 }}
 data:
   fylr.yml: |
-    fylr:
+    fylr+:
       name: {{ include "fylr.fullname" . }}
       externalURL: {{ .Values.fylr.externalURL }}
       {{- if .Values.fylr.license }}
@@ -72,15 +72,16 @@ data:
         connectTimeoutSec: {{ .Values.fylr.execserver.connectTimeoutSec | default 240 }}
         callbackBackendInternalURL: "http://{{ include "fylr.service-backend-name" . }}.{{ .Release.Namespace }}.svc:{{ .Values.services.backend.port }}"
         callbackApiInternalURL: "http://{{ include "fylr.service-api-name" . }}.{{ .Release.Namespace }}.svc:{{ .Values.services.api.port }}"
-        addresses: {{ if and (ne .Values.execserver.enabled true) (not .Values.fylr.execserver.addresses) }}[]{{ else }}
+        addresses:
           {{- if .Values.execserver.enabled }}
           - "http://{{ .Release.Name }}-execserver.{{ .Release.Namespace }}.svc:8070/?pretty=true"
+          {{- else }}
+          - "http://localhost:8070/?pretty=true"
           {{- end }}
           {{- if .Values.fylr.execserver.addresses }}
           {{- toYaml .Values.fylr.execserver.addresses | nindent 10 }}
           {{- end }}
-          {{- end }}
-      services:
+      services+:
         webapp:
           addr: :8080
           oauth2:
@@ -122,7 +123,18 @@ data:
               fylrctl: fylrctl
               psql: psql
               sqlite3: sqlite3
+        {{- if .Values.execserver.enabled }}
+        execserver:
+        {{- else }}
+        execserver+:
+          addr: :8070
+          tempDir: /tmp/fylr
+          waitgroups+:
+            {{- range $k, $v := .Values.fylr.execserver.waitGroups }}
+            {{ $k }}:
+              processes: {{ $v -}}
+            {{ end }}
+        {{- end }}
       {{ if .Values.fylr.persistent.tmp.enabled -}}
       tempDir: /fylr/tmpdir
       {{- end }}
-


### PR DESCRIPTION
# Description

new feature: 
* If separate execserver is not enabled, then enable the one in the main fylr pod

(Internal Programmfabrik issue #73068)

## How Has This Been Tested?

* deployment with the new feature
* deployment with the default (old behavior is still the default)
 * this test currently fails