### PR TITLE
allow http-only

### DIFF
--- a/charts/fylr/Chart.yaml
+++ b/charts/fylr/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.95
+version: 0.1.96
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/fylr/templates/configmap.yaml
+++ b/charts/fylr/templates/configmap.yaml
@@ -97,6 +97,7 @@ data:
           webDAVHotfolderPath: /fylr/webDAVHotfolder
           addr: :8081
           oauth2Server:
+            allowHttpRedirects: {{ .Values.fylr.services.api.oauth2Server.allowHttpRedirects | default false }}
             clients:
               fylr-web-frontend:
                 redirectURIs:

--- a/charts/fylr/values.yaml
+++ b/charts/fylr/values.yaml
@@ -454,6 +454,8 @@ fylr:
     api:
       # -- (object) configures oauth2 related settings
       oauth2Server:
+        # default: false. Set to true if you want to avoid https and only use http. Not needed for 127.0.0.1
+        allowHttpRedirects: true
         # -- (object) additional oauth2 clients to be added to the oauth2 server.
         # For the web application, we automatically generate a key pair and assign it to the oauth2 client.
         clients:


### PR DESCRIPTION
# Description

allow to run fylr with http only

useful for quickly testing helm charts