### PR TITLE
allow to specify an encryption key for fylr configuration

### DIFF
--- a/charts/fylr/templates/secrets.yaml
+++ b/charts/fylr/templates/secrets.yaml
@@ -56,7 +56,11 @@ metadata:
     helm.sh/resource-policy: keep
 type: Opaque
 stringData:
+{{- if .Values.fylr.encryptionKey }}
+  encryptionKey: {{ .Values.fylr.encryptionKey }}
+{{ else }}
   encryptionKey: {{ randAlphaNum 32 | quote }}
+{{ end }}
   signinSecret: {{ randAlphaNum 32 | quote }}
 {{ if .Values.fylr.db.init.config }}
 ---

--- a/charts/fylr/values.yaml
+++ b/charts/fylr/values.yaml
@@ -138,6 +138,9 @@ fylr:
 
   allowPurge: true
 
+  # -- (string) encryption key for passwords and other sensible data in fylr, if not set a random key will be generated
+  encryptionKey: ""
+
   ## Configure liveness, readiness and startup probes
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
   ##


### PR DESCRIPTION
currently, whenever a new version of the helm chart is deployed, the fylr encryption key gets recreated and causes problems with stored smtp passwords or s3 secret keys; to avoid this, the key can be defined in the chart to be consistent across deployments