### PR TITLE
Add support for extra volumes and volume mounts

### DIFF
--- a/charts/execserver/Chart.yaml
+++ b/charts/execserver/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.95
+version: 0.1.96
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/execserver/templates/deployment.yaml
+++ b/charts/execserver/templates/deployment.yaml
@@ -60,6 +60,11 @@ spec:
             - mountPath: /tmp
               name: execserver-tmp
             {{- end }}
+
+            {{- with .Values.extraVolumeMounts }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+
       volumes:
         - name: "fylr-config"
           configMap:
@@ -69,6 +74,12 @@ spec:
           persistentVolumeClaim:
             claimName: {{ include "execserver.storage.volumes.tmp.name" . }}
         {{- end }}
+
+        {{- with .Values.extraVolumes }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+
+
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/execserver/values.yaml
+++ b/charts/execserver/values.yaml
@@ -64,6 +64,11 @@ service:
 # -- extra environment variables
 extraEnvVars: []
 
+# -- extra volume mounts
+extraVolumes: []
+extraVolumeMounts: []
+
+
 # -- Whether to configure monitoring for the application
 monitoring:
   # -- Whether to create a ServiceMonitor resource for Prometheus Operator


### PR DESCRIPTION
# Description

This change introduces support for configuring extra volumes and volume mounts in the application. It enables users to define additional storage options and integrate custom configurations as per requirement. 

Fixes: -

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [ ] Test A  
- [ ] Test B  

**Test Configuration**:

- Kubernetes version:  
- Kubectl version:  
- Helm version:  
- Node operation system:  

## Checklist

- [ ] My code follows the style guidelines of this project  
- [ ] I have performed a self-review of my own code  
- [ ] I have commented my code, particularly in hard-to-understand areas  
- [ ] I have made corresponding changes to the documentation  
- [ ] My changes generate no new warnings  
- [ ] I have added tests that prove my fix is effective or that my feature works  